### PR TITLE
Make the inclusion compatible when tags

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,7 @@
   notify: restart nginx_exporter
 
 - name: install service
-  include: service-{{ prometheus_exporter_service_mgr }}.yml
+  include_tasks: service-{{ prometheus_exporter_service_mgr }}.yml
 
 - name: Service Enabled
   become: true


### PR DESCRIPTION
Use include_tasks, to not trigger inclusion when it's not actually required. Like when tag-targeting is used.